### PR TITLE
make cc12m downloader fast

### DIFF
--- a/general/cc12m.py
+++ b/general/cc12m.py
@@ -3,12 +3,14 @@ import os
 import requests
 from pathlib import Path
 from PIL import Image
-from pandarallel import pandarallel
-pandarallel.initialize()
 from tqdm import tqdm
+from multiprocessing import Pool
+
 
 # https://github.com/google-research-datasets/conceptual-12m
 cc_url = 'https://storage.googleapis.com/conceptual_12m/cc12m.tsv'
+
+root_folder = ''
 
 def download(url: str, fname: str):
     resp = requests.get(url, stream=True)
@@ -24,17 +26,16 @@ def download(url: str, fname: str):
             size = file.write(data)
             bar.update(size)
 
-if not os.path.isfile('cc12m.tsv'):
+if not os.path.isfile(root_folder + '/cc12m.tsv'):
     print('Missing cc12m url-caption-dataset. Downloading...')
 else:
     print('cc12m.tsv already downloaded. Proceeding with downloading images!')
 
-dfc = pd.read_csv("cc12m.tsv", sep='\t', names=["url", "caption"])
-
-image_folder = 'images'
-text_folder = 'texts'
-output_folder = 'output'
-skip_folder = 'skip'
+dfc = pd.read_csv(root_folder + "/cc12m.tsv", sep='\t', names=["url", "caption"])
+image_folder = root_folder + '/images'
+text_folder = root_folder + '/texts'
+output_folder = root_folder + '/output'
+skip_folder = root_folder + '/skip'
 paths = [image_folder, text_folder, output_folder, skip_folder]
 for path in paths:
     os.makedirs(path, exist_ok=True)
@@ -46,18 +47,20 @@ remaining = total - len(skiplist)
 percent_remaining = 100 * (total - remaining) / total
 maxwidth = 256
 maxheight = 256
+thread_count = 32
 
 df = dfc.loc[~dfc.index.isin(skiplist)]
 print('Remaining {} images to be downloaded - {} ({:.5f} %) already downloaded.'.format(remaining, len(skiplist), percent_remaining))
 
 def load_image_and_caption(x):
-    id = "0"*(9-len(str(x.name))) + str(x.name)
+    name, url, caption = x
+    id = "0"*(9-len(str(name))) + str(name)
     suffix = ''
-    ending = x.url.split('.')[-1].lower()
+    ending = url.split('.')[-1].lower()
     if ending.lower() in imageformats:
         suffix = '.' + ending
     try:
-        foo = Image.open(requests.get(x.url, stream=True, timeout=3).raw)
+        foo = Image.open(requests.get(url, stream=True, timeout=3).raw)
         a = max(maxwidth/foo.size[0], maxheight/foo.size[1])
         foo = foo.resize((int(foo.size[0] * a), int(foo.size[1] * a)), Image.ANTIALIAS)
         foo.save(Path(image_folder + "/" + id + '.jpg'), optimize=True, quality=85)
@@ -66,7 +69,10 @@ def load_image_and_caption(x):
         pass
     else:
         with open(Path(text_folder + '/' + id + '.txt'), 'w') as f:
-            f.write(x.caption)
+            f.write(caption)
 
-df.parallel_apply(lambda x: load_image_and_caption(x), axis=1)
+z = zip(df.index, df["url"], df["caption"])
+pool = Pool(thread_count)
+for _ in tqdm(pool.imap_unordered(load_image_and_caption, z), total=len(df)):
+        pass
 print('Finished downloading available images from conceptual images!')

--- a/general/cc12m.py
+++ b/general/cc12m.py
@@ -5,26 +5,14 @@ from pathlib import Path
 from PIL import Image
 from tqdm import tqdm
 from multiprocessing import Pool
+import gc
+import glob
 
 
 # https://github.com/google-research-datasets/conceptual-12m
 cc_url = 'https://storage.googleapis.com/conceptual_12m/cc12m.tsv'
 
 root_folder = ''
-
-def download(url: str, fname: str):
-    resp = requests.get(url, stream=True)
-    total = int(resp.headers.get('content-length', 0))
-    with open(fname, 'wb') as file, tqdm(
-        desc=fname,
-        total=total,
-        unit='iB',
-        unit_scale=True,
-        unit_divisor=1024,
-    ) as bar:
-        for data in resp.iter_content(chunk_size=1024):
-            size = file.write(data)
-            bar.update(size)
 
 if not os.path.isfile(root_folder + '/cc12m.tsv'):
     print('Missing cc12m url-caption-dataset. Downloading...')
@@ -39,40 +27,84 @@ skip_folder = root_folder + '/skip'
 paths = [image_folder, text_folder, output_folder, skip_folder]
 for path in paths:
     os.makedirs(path, exist_ok=True)
-imageformats = ['jpg', 'jpeg', 'bmp', 'png']
-skips = os.listdir(skip_folder) + [x[:-4] for x in os.listdir(text_folder)]
 total = 12423374
-skiplist = [int(x) for x in skips]
-remaining = total - len(skiplist)
-percent_remaining = 100 * (total - remaining) / total
 maxwidth = 256
 maxheight = 256
-thread_count = 32
+thread_count = 64
+
+
+def load_caption(x):
+    name, caption = x
+    subdir = str(int(int(name) / 10000 )) 
+    if not os.path.exists(text_folder+"/"+subdir):
+        try:
+            os.makedirs(text_folder+"/"+subdir)
+        except:
+            pass
+    id = subdir + "/" + "0"*(9-len(str(name))) + str(name)
+    with open(Path(text_folder + '/' + id + '.txt'), 'w') as f:
+        f.write(caption)
+
+def list_ids(path):
+    return [int(os.path.splitext(os.path.basename(a))[0]) for a in glob.glob(path+"/**/*")]
+
+skiplist = list_ids(text_folder)
+remaining = total - len(skiplist)
+percent_remaining = 100 * (total - remaining) / total
+df = dfc.loc[~dfc.index.isin(skiplist)]
+print('Remaining {} captions to be written - {} ({:.5f} %) already written.'.format(remaining, len(skiplist), percent_remaining))
+if len(df) > 0:
+    captions = zip(df.index, df["caption"])
+    pool = Pool(16)
+    for _ in tqdm(pool.imap_unordered(load_caption, captions), total=len(df)):
+            pass
+    pool.close()
+print('Done with captions!')
+
+
+def load_image(x):
+    name, url = x
+    subdir = str(int(int(name) / 10000 )) 
+    if not os.path.exists(image_folder+"/"+subdir):
+        try:
+            os.makedirs(image_folder+"/"+subdir)
+        except:
+            pass
+    id = subdir + "/" + "0"*(9-len(str(name))) + str(name)
+    try:
+        with Image.open(requests.get(url,
+            headers={'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0'}, 
+            stream=True, timeout=3).raw) as foo:
+            a = max(maxwidth/foo.size[0], maxheight/foo.size[1])
+            foo = foo.resize((int(foo.size[0] * a), int(foo.size[1] * a)), Image.ANTIALIAS)
+            with open(Path(image_folder + "/" + id + '.jpg'), 'wb') as file:
+                foo.save(file, optimize=True, quality=85)
+    except Exception:
+        if not os.path.exists(skip_folder+"/"+subdir):
+            try:
+                os.makedirs(skip_folder+"/"+subdir)
+            except:
+                pass
+        open(Path(skip_folder + '/' + id), 'a').close
+        pass
+
+skiplist = list_ids(skip_folder) + list_ids(image_folder)
+remaining = total - len(skiplist)
+percent_remaining = 100 * (total - remaining) / total
 
 df = dfc.loc[~dfc.index.isin(skiplist)]
 print('Remaining {} images to be downloaded - {} ({:.5f} %) already downloaded.'.format(remaining, len(skiplist), percent_remaining))
+images = list(zip(df.index, df["url"]))
 
-def load_image_and_caption(x):
-    name, url, caption = x
-    id = "0"*(9-len(str(name))) + str(name)
-    suffix = ''
-    ending = url.split('.')[-1].lower()
-    if ending.lower() in imageformats:
-        suffix = '.' + ending
-    try:
-        foo = Image.open(requests.get(url, stream=True, timeout=3).raw)
-        a = max(maxwidth/foo.size[0], maxheight/foo.size[1])
-        foo = foo.resize((int(foo.size[0] * a), int(foo.size[1] * a)), Image.ANTIALIAS)
-        foo.save(Path(image_folder + "/" + id + '.jpg'), optimize=True, quality=85)
-    except Exception:
-        open(Path(skip_folder + '/' + id), 'a').close
-        pass
-    else:
-        with open(Path(text_folder + '/' + id + '.txt'), 'w') as f:
-            f.write(caption)
+batch = 20000
 
-z = zip(df.index, df["url"], df["caption"])
-pool = Pool(thread_count)
-for _ in tqdm(pool.imap_unordered(load_image_and_caption, z), total=len(df)):
+for i in tqdm(range(0, len(df), batch)):
+    pool = Pool(thread_count)
+    for _ in tqdm(pool.imap_unordered(load_image, images[i:i+batch]), total=batch):
         pass
+    pool.terminate()
+    pool.join()
+    del pool
+    gc.collect()
+
 print('Finished downloading available images from conceptual images!')


### PR DESCRIPTION
* use multiprocessing pool instead of pandaparallel: allow increasing the number of threads a lot more thanks to better memory handling
* add thread parameter
* add root_folder param (unrelated but good change)

for 32GB of ram I used 192 threads and manage to download at 60MB/s which corresponds to 300 sample/s
that means 11h to download the dataset

before that change I was barely reaching 3MB/s

I recommend using https://github.com/uploadcare/pillow-simd instead of pillow for speed but not committing to setup.py as it might not work on all downloaders, maybe for another PR.